### PR TITLE
Update fabric.mod.json

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.15.10",
-    "fabric": "*",
+    "fabric-api": "*",
     "minecraft": ">=$minecraft_version"
   }
 }


### PR DESCRIPTION
Similar to [Geyser#5272](https://github.com/GeyserMC/Geyser/pull/5272), this PR uses the updated mod ID of the Fabric API (`fabric-api`), which makes the error that appears to users clearer when Fabric API is not installed (`requires any version of fabric` turns into `requires any version of fabric-api`).

The mod ID of the Fabric API has been `fabric-api` for 3 years now, see Fabric API's [`fabric.mod.json`](https://github.com/FabricMC/fabric/blob/1.21.4/src/main/resources/fabric.mod.json).