### PR TITLE
Floodgate for 1.21.9

### DIFF
--- a/fabric/src/main/java/org/geysermc/floodgate/platform/fabric/pluginmessage/FabricPluginMessageRegistration.java
+++ b/fabric/src/main/java/org/geysermc/floodgate/platform/fabric/pluginmessage/FabricPluginMessageRegistration.java
@@ -20,7 +20,7 @@ public class FabricPluginMessageRegistration implements PluginMessageRegistratio
                         ((payload, context) -> channel.handleServerCall(
                                 payload.data(),
                                 context.player().getUUID(),
-                                context.player().getGameProfile().getName())));
+                                context.player().getGameProfile().name())));
             }
             case "floodgate:packet" -> {
                 PayloadTypeRegistry.playC2S().register(PacketPayload.TYPE, PacketPayload.STREAM_CODEC);
@@ -29,7 +29,7 @@ public class FabricPluginMessageRegistration implements PluginMessageRegistratio
                         ((payload, context) -> channel.handleServerCall(
                                 payload.data(),
                                 context.player().getUUID(),
-                                context.player().getGameProfile().getName())));
+                                context.player().getGameProfile().name())));
             }
             case "floodgate:skin" -> {
                 PayloadTypeRegistry.playC2S().register(SkinPayload.TYPE, SkinPayload.STREAM_CODEC);
@@ -38,7 +38,7 @@ public class FabricPluginMessageRegistration implements PluginMessageRegistratio
                         ((payload, context) -> channel.handleServerCall(
                                 payload.data(),
                                 context.player().getUUID(),
-                                context.player().getGameProfile().getName())));
+                                context.player().getGameProfile().name())));
             }
             case "floodgate:transfer" -> {
                 PayloadTypeRegistry.playC2S().register(TransferPayload.TYPE, TransferPayload.STREAM_CODEC);
@@ -47,7 +47,7 @@ public class FabricPluginMessageRegistration implements PluginMessageRegistratio
                         ((payload, context) -> channel.handleServerCall(
                                 payload.data(),
                                 context.player().getUUID(),
-                                context.player().getGameProfile().getName())));
+                                context.player().getGameProfile().name())));
             }
             default -> throw new IllegalArgumentException("unknown channel: " + channel);
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,6 @@ org.gradle.caching=true
 org.gradle.vfs.watch=false
 
 # Mod Properties
-version=2.2.5-SNAPSHOT
+version=2.2.6-SNAPSHOT
 group=org.geysermc.floodgate
 id=floodgate-modded

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-geyser = "2.7.2-SNAPSHOT"
+geyser = "2.8.4-SNAPSHOT"
 blossom = "1.2.0"
 indra = "3.1.3"
 shadow = "8.1.1"
 architectury-plugin = "3.4-SNAPSHOT"
-architectury-loom = "1.10-SNAPSHOT"
-minecraft-version = "1.21.6"
+architectury-loom = "1.11-SNAPSHOT"
+minecraft-version = "1.21.9"
 minotaur = "2.+"
 guice = "6.0.0"
 cloud = "2.0.0-beta.11"
@@ -17,12 +17,12 @@ asm = "5.2"
 floodgate = "core-repackage-2.2.3-SNAPSHOT"
 
 # fabric
-fabric-loader = "0.16.14"
-fabric-api = "0.127.1+1.21.6"
-fabric-permissions-api = "0.4.1-SNAPSHOT"
+fabric-loader = "0.17.2"
+fabric-api = "0.133.14+1.21.9"
+fabric-permissions-api = "0.4.1"
 
 # neoforge
-neoforge-version = "21.6.11-beta"
+neoforge-version = "21.9.1-beta"
 
 [libraries]
 floodgate-core = { group = "org.geysermc.floodgate", name = "core", version.ref = "floodgate" }

--- a/mod/src/main/java/org/geysermc/floodgate/mod/data/ModDataHandler.java
+++ b/mod/src/main/java/org/geysermc/floodgate/mod/data/ModDataHandler.java
@@ -25,6 +25,7 @@ import org.geysermc.floodgate.mod.mixin.ConnectionMixin;
 import org.slf4j.Logger;
 
 import java.net.InetSocketAddress;
+import java.util.Objects;
 
 public final class ModDataHandler extends CommonDataHandler {
     private static final Logger LOGGER = LogUtils.getLogger();
@@ -134,10 +135,10 @@ public final class ModDataHandler extends CommonDataHandler {
             public void run() {
                 GameProfile effectiveProfile = gameProfile;
                 try {
-                    MinecraftSessionService service = MinecraftServerHolder.get().getSessionService();
-                    effectiveProfile = service.fetchProfile(effectiveProfile.getId(), true).profile();
+                    MinecraftSessionService service = MinecraftServerHolder.get().services().sessionService();
+                    effectiveProfile = Objects.requireNonNull(service.fetchProfile(effectiveProfile.id(), true)).profile();
                 } catch (Exception e) {
-                    LOGGER.error("Unable to get Bedrock linked player textures for " + effectiveProfile.getName(), e);
+                    LOGGER.error("Unable to get Bedrock linked player textures for " + effectiveProfile.name(), e);
                 }
                 packetListener.startClientVerification(effectiveProfile);
             }

--- a/mod/src/main/java/org/geysermc/floodgate/mod/mixin/PlayerAccessor.java
+++ b/mod/src/main/java/org/geysermc/floodgate/mod/mixin/PlayerAccessor.java
@@ -1,0 +1,17 @@
+package org.geysermc.floodgate.mod.mixin;
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Player.class)
+public interface PlayerAccessor {
+
+    @Accessor
+    @Final
+    @Mutable
+    void setGameProfile(GameProfile profile);
+}

--- a/mod/src/main/java/org/geysermc/floodgate/mod/pluginmessage/ModSkinApplier.java
+++ b/mod/src/main/java/org/geysermc/floodgate/mod/pluginmessage/ModSkinApplier.java
@@ -1,5 +1,8 @@
 package org.geysermc.floodgate.mod.pluginmessage;
 
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
+import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import com.mojang.authlib.properties.PropertyMap;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoRemovePacket;
@@ -12,6 +15,7 @@ import org.geysermc.floodgate.api.player.FloodgatePlayer;
 import org.geysermc.floodgate.core.skin.SkinApplier;
 import org.geysermc.floodgate.mod.MinecraftServerHolder;
 import org.geysermc.floodgate.mod.mixin.ChunkMapMixin;
+import org.geysermc.floodgate.mod.mixin.PlayerAccessor;
 
 import java.util.Collections;
 
@@ -30,10 +34,10 @@ public final class ModSkinApplier implements SkinApplier {
             }
 
             // Apply the new skin internally
-            PropertyMap properties = bedrockPlayer.getGameProfile().getProperties();
-
-            properties.removeAll("textures");
+            Multimap<String, Property> properties = MultimapBuilder.hashKeys().arrayListValues().build();
             properties.put("textures", new Property("textures", skinData.value(), skinData.signature()));
+            ((PlayerAccessor) bedrockPlayer).setGameProfile(new GameProfile(bedrockPlayer.getGameProfile().id(),
+                bedrockPlayer.getGameProfile().name(), new PropertyMap(properties)));
 
             ChunkMap tracker = ((ServerLevel) bedrockPlayer.level).getChunkSource().chunkMap;
             ChunkMap.TrackedEntity entry = ((ChunkMapMixin) tracker).getEntityMap().get(bedrockPlayer.getId());

--- a/mod/src/main/java/org/geysermc/floodgate/mod/util/ModCommandUtil.java
+++ b/mod/src/main/java/org/geysermc/floodgate/mod/util/ModCommandUtil.java
@@ -1,10 +1,10 @@
 package org.geysermc.floodgate.mod.util;
 
-import com.mojang.authlib.GameProfile;
 import lombok.Setter;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.players.NameAndId;
 import net.minecraft.server.players.UserWhiteListEntry;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.floodgate.api.FloodgateApi;
@@ -42,13 +42,13 @@ public final class ModCommandUtil extends CommandUtil {
         }
         ServerPlayer player = stack.getPlayer();
         //Locale locale = PlayerLocales.locale(player);
-        return new UserAudience.PlayerAudience(player.getUUID(), player.getGameProfile().getName(), "en_US",
+        return new UserAudience.PlayerAudience(player.getUUID(), player.getGameProfile().name(), "en_US",
                 stack, this, true);
     }
 
     @Override
     protected String getUsernameFromSource(@NonNull Object source) {
-        return ((ServerPlayer) source).getGameProfile().getName();
+        return ((ServerPlayer) source).getGameProfile().name();
     }
 
     @Override
@@ -99,15 +99,15 @@ public final class ModCommandUtil extends CommandUtil {
 
     @Override
     public boolean whitelistPlayer(UUID uuid, String username) {
-        GameProfile profile = new GameProfile(uuid, username);
-        MinecraftServerHolder.get().getPlayerList().getWhiteList().add(new UserWhiteListEntry(profile));
+        NameAndId nameAndId = new NameAndId(uuid, username);
+        MinecraftServerHolder.get().getPlayerList().getWhiteList().add(new UserWhiteListEntry(nameAndId));
         return true;
     }
 
     @Override
     public boolean removePlayerFromWhitelist(UUID uuid, String username) {
-        GameProfile profile = new GameProfile(uuid, username);
-        MinecraftServerHolder.get().getPlayerList().getWhiteList().remove(profile);
+        NameAndId nameAndId = new NameAndId(uuid, username);
+        MinecraftServerHolder.get().getPlayerList().getWhiteList().remove(nameAndId);
         return true;
     }
 }

--- a/mod/src/main/resources/floodgate.mixins.json
+++ b/mod/src/main/resources/floodgate.mixins.json
@@ -11,7 +11,7 @@
     "FloodgateUtilMixin",
     "GeyserModInjectorMixin",
     "ServerConnectionListenerMixin",
-      "PlayerAccessor"
+     "PlayerAccessor"
   ],
   "plugin": "org.geysermc.floodgate.mod.util.ModMixinConfigPlugin",
   "injectors": {

--- a/mod/src/main/resources/floodgate.mixins.json
+++ b/mod/src/main/resources/floodgate.mixins.json
@@ -10,7 +10,8 @@
     "ConnectionMixin",
     "FloodgateUtilMixin",
     "GeyserModInjectorMixin",
-    "ServerConnectionListenerMixin"
+    "ServerConnectionListenerMixin",
+      "PlayerAccessor"
   ],
   "plugin": "org.geysermc.floodgate.mod.util.ModMixinConfigPlugin",
   "injectors": {

--- a/neoforge/src/main/java/org/geysermc/floodgate/platform/neoforge/NeoForgeFloodgateMod.java
+++ b/neoforge/src/main/java/org/geysermc/floodgate/platform/neoforge/NeoForgeFloodgateMod.java
@@ -39,7 +39,7 @@ public final class NeoForgeFloodgateMod extends FloodgateMod {
 
         modEventBus.addListener(this::onRegisterPackets);
         NeoForge.EVENT_BUS.addListener(this::onServerStarted);
-        if (FMLLoader.getDist().isClient()) {
+        if (FMLLoader.getCurrent().getDist().isClient()) {
             NeoForge.EVENT_BUS.addListener(this::onClientStop);
         } else {
             NeoForge.EVENT_BUS.addListener(this::onServerStop);
@@ -69,12 +69,12 @@ public final class NeoForgeFloodgateMod extends FloodgateMod {
 
     @Override
     public @Nullable Path resourcePath(String file) {
-        return container.getModInfo().getOwningFile().getFile().findResource(file);
+        return container.getModInfo().getOwningFile().getFile().getContents().findFile(file).map(Path::of).orElse(null);
     }
 
     @Override
     public boolean isClient() {
-        return FMLLoader.getDist().isClient();
+        return FMLLoader.getCurrent().getDist().isClient();
     }
 
 }

--- a/neoforge/src/main/java/org/geysermc/floodgate/platform/neoforge/pluginmessage/NeoForgePluginMessageRegistration.java
+++ b/neoforge/src/main/java/org/geysermc/floodgate/platform/neoforge/pluginmessage/NeoForgePluginMessageRegistration.java
@@ -20,19 +20,19 @@ public class NeoForgePluginMessageRegistration implements PluginMessageRegistrat
             case "floodgate:form" ->
                     registrar.playBidirectional(FormPayload.TYPE, FormPayload.STREAM_CODEC, (payload, context) ->
                             channel.handleServerCall(payload.data(), context.player().getUUID(),
-                                    context.player().getGameProfile().getName()));
+                                    context.player().getGameProfile().name()));
             case "floodgate:packet" ->
                     registrar.playBidirectional(PacketPayload.TYPE, PacketPayload.STREAM_CODEC, (payload, context) ->
                             channel.handleServerCall(payload.data(), context.player().getUUID(),
-                                    context.player().getGameProfile().getName()));
+                                    context.player().getGameProfile().name()));
             case "floodgate:skin" ->
                     registrar.playBidirectional(SkinPayload.TYPE, SkinPayload.STREAM_CODEC, (payload, context) ->
                             channel.handleServerCall(payload.data(), context.player().getUUID(),
-                                    context.player().getGameProfile().getName()));
+                                    context.player().getGameProfile().name()));
             case "floodgate:transfer" ->
                     registrar.playBidirectional(TransferPayload.TYPE, TransferPayload.STREAM_CODEC, (payload, context) ->
                             channel.handleServerCall(payload.data(), context.player().getUUID(),
-                                    context.player().getGameProfile().getName()));
+                                    context.player().getGameProfile().name()));
             default -> throw new IllegalArgumentException("unknown channel: " + channel);
         }
     }


### PR DESCRIPTION
This PR updates Floodgate-Modded to support 1.21.9. Support for earlier versions has been dropped as breaking changes have been made.

PR mostly consists of renames. A change has been made to skin applying, as `GameProfile`s are no longer mutable we now have to create a new property map and `GameProfile`, and use a mixin to set it on the player.

PR builds, but has not been tested yet.